### PR TITLE
fix description typo in agenda page

### DIFF
--- a/src/assets/js/agenda.js
+++ b/src/assets/js/agenda.js
@@ -104,7 +104,7 @@ $('.agenda-session[data-id]').on('click', function (e) {
         `)
   })
   $('.agenda-speaker', bodyTmplDom).append('<hr>')
-  $('.agenda-description', bodyTmplDom).html(marked.parse(session[currentLang]['description']))
+  $('.agenda-description', bodyTmplDom).html(marked.parse(session[currentLang]['description'], { breaks: true }))
   $('#modal .head-group h4').text(session[currentLang]['title'])
   let tagGroup = $('.tag-group', this)
   $('#modal .tag-group').html(tagGroup.clone().removeClass('hidden'))


### PR DESCRIPTION
修正議程介紹中換行字元消失的情況

Before:
<img width="523" alt="截圖 2024-05-05 下午2 47 30" src="https://github.com/g0v/summit2024/assets/22187384/5efca994-24d9-44ee-9a48-a6448c59db5b">

After:
<img width="523" alt="截圖 2024-05-05 下午3 04 20" src="https://github.com/g0v/summit2024/assets/22187384/28e3f699-d5ef-4e59-863e-668111294580">
